### PR TITLE
Consul already uses first available IP Address

### DIFF
--- a/debian/consul.upstart
+++ b/debian/consul.upstart
@@ -9,9 +9,6 @@ script
   # Make sure to use all our CPUs, because Consul can block a scheduler thread
   export GOMAXPROCS=`nproc`
 
-  # Get the public IP of the first ethernet interface
-  BIND=`ifconfig eth0 | grep "inet addr" | awk '{ print substr($2,6) }'`
-
   # Allow overriding env vars in /etc/default/consul
   if [ -f "/etc/default/consul" ]; then
     . /etc/default/consul
@@ -19,6 +16,5 @@ script
   
   exec /usr/bin/consul agent \
     -config-dir="/etc/consul.d" \
-    -bind=$BIND \
     ${CONSUL_FLAGS}
 end script


### PR DESCRIPTION
According to consul documentation for the BIND directive -

> This is an IP address that should be reachable by all other nodes in the cluster. By default this is "0.0.0.0", meaning Consul will use the first available private IP address.

http://www.consul.io/docs/agent/options.html#_bind

There is no need (that I can think of) to do a bind here in the upstart script.