### PR TITLE
Using the HTTPS Git URL of the Consul repository. As only read access is...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ create_upstream_tarball: get_new_version
 	fi
 
 $(SRC_DIR):
-	git clone git@github.com:hashicorp/consul.git $(SRC_DIR)
+	git clone https://github.com/hashicorp/consul.git $(SRC_DIR)
 
 get_current_version:
 	$(eval CURRENT_VERSION = $(shell test -f debian/changelog && \


### PR DESCRIPTION
... required this is easier to use in some circumstances.