### PR TITLE
d/postinst: Do not run consul and consul-web as uid 0

### DIFF
--- a/debian/consul.service
+++ b/debian/consul.service
@@ -9,6 +9,8 @@ Environment=GOMAXPROCS=2
 EnvironmentFile=/etc/default/consul
 ExecStart=/usr/bin/consul agent -config-dir=/etc/consul.d $CONSUL_FLAGS
 ExecReload=/bin/kill -HUP $MAINPID
+User=consul
+Group=consul
 Restart=on-failure
 RestartSec=10
 LimitNOFILE=infinity

--- a/debian/consul.upstart
+++ b/debian/consul.upstart
@@ -8,13 +8,17 @@ respawn
 script
   # Make sure to use all our CPUs, because Consul can block a scheduler thread
   export GOMAXPROCS=`nproc`
+  USER="consul"
+  GROUP="consul"
+  OPTS="agent -config-dir="/etc/consul.d ${CONSUL_FLAGS}"
 
   # Allow overriding env vars in /etc/default/consul
   if [ -f "/etc/default/consul" ]; then
     . /etc/default/consul
   fi
 
-  exec /usr/bin/consul agent \
-    -config-dir="/etc/consul.d" \
-    ${CONSUL_FLAGS}
+  setuid $USER
+  setgid $GROUP
+  exec /usr/bin/consul $OPTS
+
 end script

--- a/debian/control
+++ b/debian/control
@@ -6,12 +6,16 @@ Homepage: http://www.consul.io
 Vcs-Git: https://github.com/hashicorp/consul.git
 Vcs-Browser: https://github.com/hashicorp/consul
 Standards-Version: 3.9.8
-Build-Depends: debhelper (>= 9), golang-go (>= 2:1.6) | golang-1.6-go, git, dh-systemd
+Build-Depends: adduser,
+               debhelper (>= 9),
+               dh-systemd,
+               git,
+               golang-go (>= 2:1.6) | golang-1.6-go
 
 Package: consul
 Architecture: any
 Suggests: consul-web-ui
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: adduser, ${misc:Depends}, ${shlibs:Depends}
 Description: service discovery and configuration tool - main package
  Consul is a tool for service discovery and configuration. Consul is
  distributed, highly available, and extremely scalable. Consul provides
@@ -35,7 +39,7 @@ Description: service discovery and configuration tool - main package
 Package: consul-web-ui
 Section: utils
 Architecture: all
-Depends: consul, ${misc:Depends}
+Depends: adduser, consul, ${misc:Depends}
 Description: service discovery and configuration tool - web user interface
  Consul is a tool for service discovery and configuration. Consul is
  distributed, highly available, and extremely scalable. Consul provides

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+    configure)
+
+      # Create consul user
+      if ! getent passwd consul > /dev/null 2>&1
+      then
+        adduser --system --group --quiet \
+          --no-create-home --home /nonexistent \
+          --shell /usr/sbin/nologin \
+          --gecos "Consul service discovery" consul
+      fi
+
+      chown -R consul: /etc/consul.d
+
+    ;;
+esac
+
+#DEBHELPER#


### PR DESCRIPTION
Run consul as consul user, and not uid 0.

Note: `/var/lib/consul` (in the consul configuration) is not managed by the package (this directory must be owned by `consul` user)