### PR TITLE
fix `enable_syslog` configuration parameter

### DIFF
--- a/debian/consul.d/20-agent.json
+++ b/debian/consul.d/20-agent.json
@@ -1,4 +1,4 @@
 {
   "data_dir": "/var/lib/consul",
-  "syslog": true
+  "enable_syslog": true
 }


### PR DESCRIPTION
Hello!
Currently default Consul 0.6.4 installation from your PPA is broken a bit due to incorrect default configuration. According to the official documentation, there is no `syslog` option in configuration files but `enable_syslog` only.
```
[izayoi] ~ # consul agent --data-dir="/var/lib/consul" --config-dir="/etc/consul.d" --bind="10.18.0.5"
==> Error decoding '/etc/consul.d/20-agent.json': Config has invalid keys: syslog
[izayoi] ~ # sed -i.bak "s/syslog/enable_syslog/g" /etc/consul.d/20-agent.json
[izayoi] ~ # consul agent --data-dir="/var/lib/consul" --config-dir="/etc/consul.d" --bind="10.18.0.5"
==> Starting Consul agent...
==> Starting Consul agent RPC...
==> Consul agent running!
...
```